### PR TITLE
Remove dependency on ServerSslConfig

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-parent</artifactId>
-        <version>0.21.1</version>
+        <version>0.23.1</version>
     </parent>
 
     <artifactId>quarkus-grpc-deployment</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,14 +21,14 @@
     <parent>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-build-parent</artifactId>
-        <version>0.21.1</version>
+        <version>0.23.1</version>
     </parent>
 
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-grpc-parent</artifactId>
     <name>Quarkus - gRPC</name>
     <packaging>pom</packaging>
-    <version>0.21.1</version>
+    <version>0.23.1</version>
 
     <licenses>
         <license>
@@ -45,7 +45,7 @@
 
         <grpc.version>1.22.0</grpc.version>
         <protobuf.version>3.9.0-rc-1</protobuf.version>
-        <quarkus.version>0.21.1</quarkus.version>
+        <quarkus.version>0.23.1</quarkus.version>
     </properties>
 
     <modules>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-parent</artifactId>
-        <version>0.21.1</version>
+        <version>0.23.1</version>
     </parent>
 
     <artifactId>quarkus-grpc</artifactId>

--- a/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcConfig.java
+++ b/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcConfig.java
@@ -17,10 +17,11 @@ package io.quarkus.grpc.runtime;
 
 import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
 
+import javax.net.ssl.SSLContext;
+
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
-import io.quarkus.runtime.configuration.ssl.ServerSslConfig;
 
 /** gRPC configuration. */
 @SuppressWarnings("WeakerAccess")
@@ -42,9 +43,6 @@ public final class GrpcConfig {
     /** The secure port used to run tests */
     @ConfigItem(defaultValue = "5444")
     public int testSslPort;
-
-    /** The SSL config */
-    public ServerSslConfig ssl;
 
     /**
      * The permitted time (in ms) for new connections to complete negotiation handshakes before being killed.
@@ -70,5 +68,10 @@ public final class GrpcConfig {
 
     public int determineSslPort(LaunchMode launchMode) {
         return launchMode == LaunchMode.TEST ? testSslPort : sslPort;
+    }
+
+    public SSLContext sslContext() {
+        // not implemented
+        return null;
     }
 }

--- a/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcRecorder.java
+++ b/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcRecorder.java
@@ -40,7 +40,7 @@ public class GrpcRecorder {
     public void prepareServer(GrpcConfig config, LaunchMode launchMode) throws Exception {
         int port = config.determinePort(launchMode);
         int sslPort = config.determineSslPort(launchMode);
-        SSLContext context = config.ssl.toSSLContext();
+        SSLContext context = config.sslContext();
 
         if (context != null) {
             log.warn("SSL not yet implemented!");


### PR DESCRIPTION
io.quarkus.runtime.configuration.ssl.ServerSslConfig was moved to
the Vert.x-specific modules in Quarkus commit
96955c901f7a6ca3f51f3c319189e37dc26b3f4b, which breaks the existing
GrpcConfig code.  Since GrpcRecorder expected the SSL context to be null
anyway, this patch removes the (currently unused) configuration
reference and restores compatibility with Quarkus 0.23.1.

Also bumps the artifact version to 0.23.1 in accordance with the Quarkus
release.